### PR TITLE
Sets fastcgi_buffer_size and fastcgi_buffers to prevent fastcgi timeouts

### DIFF
--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -27,6 +27,8 @@ server {
         fastcgi_pass 127.0.0.1:9000;
         fastcgi_index VALET_SERVER_PATH;
         fastcgi_buffering off;
+        fastcgi_buffer_size 2M;
+        fastcgi_buffers 8 2M;        
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME VALET_SERVER_PATH;
     }


### PR DESCRIPTION
On two fresh WSL1/Ubuntu 20.04 instances, I had to add these two lines in order to resolve persistent request timeouts:

```
(upstream timed out (110: Connection timed out) while reading upstream, client: 127.0.0.1, server: , request: "GET /some-path HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000",...
```

In my case at least, merely having fastcgi_buffering disabled was not enough.


Source: https://github.com/microsoft/WSL/issues/3687#issuecomment-788956455